### PR TITLE
Feat/numpy 2 support

### DIFF
--- a/.github/workflows/build_matrix.py
+++ b/.github/workflows/build_matrix.py
@@ -1,0 +1,45 @@
+import json
+import sys
+
+# list of images/python combinations can be found here:
+# https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+python_version = ["3.8", "3.9", "3.10", "3.11"]
+
+# None indicates to skip that combination
+ubuntu_version = ["ubuntu-22.04", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04"]
+macos_version = ["macos-latest", "macos-latest", "macos-latest", "macos-latest"]
+windows_version = [None, None, "windows-latest", "windows-latest"]
+
+# installation, minimal version of python
+packages = [
+    ("'numpy~=1.24.0' 'scipy<1.15.0'", "3.8"),
+    ("'numpy~=1.26.0' 'scipy<1.15.0'", "3.10"),
+    ("'numpy~=1.26.0' 'scipy>=1.15.0'", "3.10"),
+    ("'numpy>=2.0' 'scipy>=1.15.0'", "3.10"),
+]
+
+configurations = []
+for idx_pv, pv in enumerate(python_version):
+    current_python_version = tuple(int(_) for _ in pv.split("."))
+
+    for os in ubuntu_version, macos_version, windows_version:
+        current_os = os[idx_pv]
+        if current_os is None:
+            continue
+
+        for pk in packages:
+
+            min_python_version = tuple(int(_) for _ in pk[1].split("."))
+            if current_python_version < min_python_version:
+                continue
+
+            current_configuration = {
+                "python-version": pv,
+                "os": current_os,
+                "packages": pk[0],
+            }
+
+            configurations += [current_configuration]
+
+with open(sys.argv[1], "w") as f:
+    json.dump(configurations, f)

--- a/.github/workflows/pytest-not-slow.yml
+++ b/.github/workflows/pytest-not-slow.yml
@@ -5,36 +5,83 @@ on:
   workflow_dispatch: # This allows us to manually trigger
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      configurations: ${{ steps.matrix.outputs.configurations }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # setting the configuration with the matrix facility of GH is a bit difficult
+      # as different versions of python need different os, different packages need
+      # different version of python, etc... at the end, it is a sparse matrix
+      # We use a script that contains the logic instead, in this same folder
+      # using vanilla python.
+      - name: Define matrix
+        id: matrix
+        run: |
+          # "$GITHUB_OUTPUT" will be a json file containing all the configurations
+          python .github/workflows/build_matrix.py "$GITHUB_OUTPUT"
+          
+          # we need to prepend with the output name, maybe we can do that directly
+          # in json?
+          echo "configurations="`cat "$GITHUB_OUTPUT"` > "$GITHUB_OUTPUT" 
+
   build:
 
     if: "!contains(github.event.head_commit.message, 'ci skip')"
-    runs-on: ${{ matrix.os }}
+
+    continue-on-error: true
+    needs: define-matrix
     strategy:
       max-parallel: 4
+      fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9'] # 3.10 hasn't been enabled on all arches yet
+        # reads the configuration from the previously defined file
+        configuration: ${{ fromJSON(needs.define-matrix.outputs.configurations) }}
+
+    runs-on: ${{ matrix.configuration.os }}
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.configuration.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.configuration.python-version }}
+        cache: 'pip' # caching pip dependencies
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt ${{ matrix.configuration.packages }}
+        pip list
+
     - name: Install package
       run: |
         pip install .
+
     - name: Lint with flake8
       run: |
         pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        
+        # stop the build if there are Python syntax errors 
+        # or undefined names
+        # note: we cannot use line breaks "\" to split this up to several lines, as
+        # windows uses "^" instead.
+        flake8 --count --exclude .git,build,__pycache__ --select=E9,F63,F7,F82 --show-source --statistics .
+      
+        # exit-zero treats all errors as warnings. 
+        # The GitHub editor is 127 chars wide
+        flake8 --count --exclude .git,build,__pycache__ --exit-zero --max-complexity=10 --max-line-length=127 --statistics .
+
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pytest-slow.yml
+++ b/.github/workflows/pytest-slow.yml
@@ -6,32 +6,63 @@ jobs:
   build:
 
     if: "!contains(github.event.head_commit.message, 'ci skip')"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os-python.image }}
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7']
+        os-python:
+          - image: ubuntu-latest
+            python-version: '3.11'
+
+        numpy-version: ['numpy~=2.1.0']
+
+        # incompatible with scipy>=1.15.0 because of the pickled elements
+        scipy-version: ['scipy~=1.13.0']
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.os-python.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.os-python.python-version }}
+        cache: 'pip' # caching pip dependencies
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt "${{ matrix.numpy-version }}" "${{ matrix.scipy-version }}"
+        pip list
+
     - name: Install package
       run: |
         pip install .
+
     - name: Lint with flake8
       run: |
         pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        
+        # stop the build if there are Python syntax errors 
+        # or undefined names
+        flake8 \
+          --count \
+          --exclude .git,build,__pycache__ \
+          --select=E9,F63,F7,F82 \
+          --show-source \
+          --statistics \
+          .
+        
+        # exit-zero treats all errors as warnings. 
+        # The GitHub editor is 127 chars wide
+        flake8 \
+          --count \
+          --exclude .git,build,__pycache__ \
+          --exit-zero \
+          --max-complexity=10 \
+          --max-line-length=127 \
+          --statistics \
+          .
+
     - name: Test with pytest
       run: |
         pip install pytest

--- a/qnm/contfrac.py
+++ b/qnm/contfrac.py
@@ -11,7 +11,7 @@ import numpy as np
 
 # Note that if we jitted `lentz`, it would only be able to run on jitted functions.
 
-def lentz(a, b, tol=1.e-10, N_min=0, N_max=np.Inf, tiny=1.e-30, args=None):
+def lentz(a, b, tol=1.e-10, N_min=0, N_max=np.inf, tiny=1.e-30, args=None):
     """Compute a continued fraction via modified Lentz's method.
 
     This implementation is by the book [1]_.  The value to compute is:
@@ -29,7 +29,7 @@ def lentz(a, b, tol=1.e-10, N_min=0, N_max=np.Inf, tiny=1.e-30, args=None):
     N_min: int [default: 0]
       Minimum number of iterations to evaluate.
 
-    N_max: int or comparable [default: np.Inf]
+    N_max: int or comparable [default: np.inf]
       Maximum number of iterations to evaluate.
 
     tiny: float [default: 1.e-30]
@@ -185,7 +185,7 @@ def lentz(a, b, tol=1.e-10, N_min=0, N_max=np.Inf, tiny=1.e-30, args=None):
     # Success or failure can be assessed by the user
     return f_new, np.abs(Delta - 1.), j-1
 
-def lentz_gen(a, b, tol=1.e-10, N_min=0, N_max=np.Inf, tiny=1.e-30):
+def lentz_gen(a, b, tol=1.e-10, N_min=0, N_max=np.inf, tiny=1.e-30):
     """ Compute a continued fraction via modified Lentz's method,
     using generators rather than functions.
 
@@ -202,7 +202,7 @@ def lentz_gen(a, b, tol=1.e-10, N_min=0, N_max=np.Inf, tiny=1.e-30):
     N_min: int [default: 0]
       Minimum number of iterations to evaluate.
 
-    N_max: int or comparable [default: np.Inf]
+    N_max: int or comparable [default: np.inf]
       Maximum number of iterations to evaluate.
 
     tiny: float [default: 1.e-30]

--- a/qnm/radial.py
+++ b/qnm/radial.py
@@ -218,7 +218,7 @@ def rad_b(i, n_inv, D):
 #Note that we do not jit the following function, since lentz is not jitted.
 
 def leaver_cf_inv_lentz_old(omega, a, s, m, A, n_inv,
-                            tol=1.e-10, N_min=0, N_max=np.Inf):
+                            tol=1.e-10, N_min=0, N_max=np.inf):
     """ Legacy function. Same as :meth:`leaver_cf_inv_lentz` except
     calling :meth:`qnm.contfrac.lentz`.  We do not jit this function
     since lentz is not jitted.  It remains here for testing purposes.
@@ -264,7 +264,7 @@ def leaver_cf_inv_lentz_old(omega, a, s, m, A, n_inv,
 
 @njit(cache=True)
 def leaver_cf_inv_lentz(omega, a, s, m, A, n_inv,
-                        tol=1.e-10, N_min=0, N_max=np.Inf):
+                        tol=1.e-10, N_min=0, N_max=np.inf):
     """Compute the n_inv inversion of the infinite continued
     fraction for solving the radial Teukolsky equation, using
     modified Lentz's method.
@@ -301,7 +301,7 @@ def leaver_cf_inv_lentz(omega, a, s, m, A, n_inv,
     N_min: int, optional [default: 0]
       Minimum number of iterations through Lentz's method.
 
-    N_max: int or comparable, optional [default: np.Inf]
+    N_max: int or comparable, optional [default: np.inf]
       Maximum number of iterations for Lentz's method.
 
     Returns

--- a/qnm/spinsequence.py
+++ b/qnm/spinsequence.py
@@ -261,7 +261,7 @@ class KerrSpinSeq(object):
                 s=0, # No smoothing!
                 k=2, ext=0)
 
-            if (True or (len(self.a) > np.Inf)): # Only do the curvature estimate after a while
+            if (True or (len(self.a) > np.inf)): # Only do the curvature estimate after a while
                 # Their second derivatives
                 d2_o_r = interp_o_r.derivative(2)
                 d2_o_i = interp_o_i.derivative(2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy
 scipy
 numba
 tqdm
-pathlib2 ; python_version < '3.4'


### PR DESCRIPTION
The changes to the code is trivial.

The complicated part is about the GH actions: a script generates all the combinations we want to build, and then uses this to build the matrix. I could not find an easy way to produce the build matrix with the mechanisms provided by GH, and I ended up in an exhaustive list in the YAML. I prefer this approach as it is easier to maintain.

Note that for the slow build, it fails for scipy<1.14 as the pickle files are referring to objects in scipy that do not exist anymore.
For the warnings, this is the same: they are emitted when the pickle files are loaded.