### PR TITLE
Run 'not slow' tests automatically for PRs

### DIFF
--- a/.github/workflows/pytest-not-slow.yml
+++ b/.github/workflows/pytest-not-slow.yml
@@ -2,6 +2,13 @@ name: Run pytest for not-slow tests
 
 on:
   push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
   workflow_dispatch: # This allows us to manually trigger
 
 jobs:


### PR DESCRIPTION
This PR modifies the github actions configuration to automatically run the `not slow` test workflow for incoming PRs (targeting `master` or a future `main` branch rename).